### PR TITLE
Fix libvips source to libvips/libvips.

### DIFF
--- a/vips.spec
+++ b/vips.spec
@@ -31,7 +31,7 @@ Summary:	C/C++ library for processing large images
 Group:		System Environment/Libraries
 License:	LGPLv2+
 URL:		http://jcupitt.github.io/libvips/
-Source0:	https://github.com/jcupitt/libvips/releases/download/v%{version}/%{name}-%{version}.tar.gz
+Source0:	https://github.com/libvips/libvips/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:	pkgconfig(glib-2.0)
 BuildRequires:	pkgconfig(gobject-introspection-1.0)


### PR DESCRIPTION
I noticed the build failing because it failed to download the source from: https://github.com/jcupitt/libvips/releases/download/v8.5.5/vips-8.5.5.tar.gz.
It looks like the easiest solution is to use the official libvips/libvips repo: https://github.com/libvips/libvips/releases/download/v8.5.5/vips-8.5.5.tar.gz